### PR TITLE
Add findByTag and replace underscore with lodash

### DIFF
--- a/lib/blogs.js
+++ b/lib/blogs.js
@@ -3,7 +3,7 @@ var path = require('path');
 var glob = require('glob');
 var marked = require('marked');
 var moment = require('moment');
-var _ = require('underscore');
+var _ = require('lodash');
 
 var blogs = [];
 
@@ -63,9 +63,22 @@ var find = function(url) {
   return url ? _.findWhere(blogs, { url: url }) : blogs;
 };
 
+var findByTag = function(tag) {
+  _reinit();
+  if (tag) {
+    var results = _.where(blogs, { tags: [tag] });
+
+    if (results !== null && results !== undefined) {
+      return results;
+    }
+  }
+  return [];
+};
+
 module.exports = {
   init: init,
-  find: find
+  find: find,
+  findByTag: findByTag
 };
 
 init();

--- a/lib/blogs.js
+++ b/lib/blogs.js
@@ -65,14 +65,7 @@ var find = function(url) {
 
 var findByTag = function(tag) {
   _reinit();
-  if (tag) {
-    var results = _.where(blogs, { tags: [tag] });
-
-    if (results !== null && results !== undefined) {
-      return results;
-    }
-  }
-  return [];
+  return _.where(blogs, { tags: [tag] });
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -18,14 +18,13 @@
     "express": "~3.2.5",
     "mustachex": "0.0.2",
     "glob": "~3.2.1",
-    "underscore": "~1.4.4",
     "marked": "~0.2.9",
-    "moment": "~2.0.0"
+    "moment": "~2.0.0",
+    "lodash": "~2.4.1"
   },
   "engines": {
     "node": "0.10.x",
     "npm": "1.2.x"
   },
-  "scripts": {
-  }
+  "scripts": {}
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,6 @@
 var config = require('../config');
 var blogs = require('../lib/blogs');
-var _ = require('underscore');
+var _ = require('lodash');
 
 var routes = function(app) {
   app.get('/', function(req, res) {
@@ -12,6 +12,16 @@ var routes = function(app) {
 
     res.render('all', { blogs: all, config: config });
   });
+
+  app.get('/tag/:tag', function(req, res, next){
+    var tagged = blogs.findByTag(req.param('tag'))
+
+    if (tagged.length === 0) {
+      return res.render('help', { config: config });
+    }
+    res.render('all', { blogs: tagged, config: config });
+  });
+
 
   app.get('/posts/:url', function(req, res, next) {
     var blog = blogs.find(req.param('url'));

--- a/views/all.html
+++ b/views/all.html
@@ -13,7 +13,7 @@
     <h3>{{relativeDate}}</h3>
 
     {{#tags}}
-      <div class="tag">{{.}}</div>
+      <div class="tag"><a href='/tag/{{.}}'>{{.}}</a></div>
     {{/tags}}
   </div>
 </div>

--- a/views/post.html
+++ b/views/post.html
@@ -11,7 +11,7 @@
     <h3>{{blog.relativeDate}}</h3>
 
     {{#blog.tags}}
-      <div class="tag">{{.}}</div>
+      <div class="tag"><a href='/tag/{{.}}'>{{.}}</a></div>
     {{/blog.tags}}
   </div>
 </div>


### PR DESCRIPTION
Allows finding articles by tag. I had to replace `underscore` with `lodash`, but see [this issue](https://github.com/JedWatson/keystone/pull/315) which has a long discussion about it and its performance, and the conclusion was to switch to lodash.

Url this uses is `/tag/{{tag}}`
